### PR TITLE
Update AWS_Help playbook title to match playbook

### DIFF
--- a/docs/AWS_Help.md
+++ b/docs/AWS_Help.md
@@ -1,4 +1,4 @@
-# Security Playbook for Responding to Amazon Bedrock Security Events
+# Security Playbook for Engaging AWS Support
 This document is provided for informational purposes only. It represents the current product offerings and practices from Amazon Web Services (AWS) as of the date of issue of this document, which are subject to change without notice. Customers are responsible for making their own independent assessment of the information in this document and any use of AWS products or services, each of which is provided “as is” without warranty of any kind, whether express or implied. This document does not create any warranties, representations, contractual commitments, conditions, or assurances from AWS, its affiliates, suppliers, or licensors. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
 
 © 2024 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This work is licensed under a Creative Commons Attribution 4.0 International License.


### PR DESCRIPTION
Update title from "Security Playbook for Responding to Amazon Bedrock Security Events" to "Security Playbook for Engaging AWS Support"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
