### PR TITLE
Detect bearer-token use on Bedrock Mantle

### DIFF
--- a/detections/Bedrock_Api_Key_Eventbridge_Detection.md
+++ b/detections/Bedrock_Api_Key_Eventbridge_Detection.md
@@ -10,7 +10,7 @@ This solution creates two EventBridge rules to monitor CloudTrail logs for speci
 ## Features
 
 - **CreateServiceSpecificCredential Monitoring**: Detects IAM API calls for credential creation
-- **Bearer Token Usage Detection**: Monitors API calls using bearer tokens
+- **Bearer Token Usage Detection**: Monitors API calls using bearer tokens, across both standard Bedrock (`bedrock.amazonaws.com`) and Bedrock Mantle (`bedrock-mantle.amazonaws.com`)
 
 
 ## Architecture

--- a/detections/cfn/bedrock-eventbridge-monitoring.yaml
+++ b/detections/cfn/bedrock-eventbridge-monitoring.yaml
@@ -205,14 +205,20 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: !Sub "${AWS::StackName}-BearerTokenUsage-Rule"
-      Description: "EventBridge rule to detect Bedrock API calls with bearer tokens"
+      Description: "EventBridge rule to detect Bedrock and Bedrock Mantle API calls with bearer tokens"
       EventPattern:
         detail-type:
           - "AWS API Call via CloudTrail"
         detail:
-          additionalEventData:
-            callWithBearerToken:
-              - true
+          # Standard Bedrock (bedrock.amazonaws.com) reports bearer-token use in additionalEventData.
+          # Bedrock Mantle (bedrock-mantle.amazonaws.com) reports it in requestParameters.
+          $or:
+            - additionalEventData:
+                callWithBearerToken:
+                  - true
+            - requestParameters:
+                callWithBearerToken:
+                  - true
       State: ENABLED
       Targets:
         - Arn: !Ref BedrockAlertsTopic

--- a/docs/Bedrock_Response.md
+++ b/docs/Bedrock_Response.md
@@ -86,7 +86,7 @@ The image below portrays the relationship between Prompts, [Agents](https://docs
 
 * Bedrock is not available in all regions (2024-06-04).  See [link](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html) for current region availability
 * Model Invocation Logging is required to view prompts and responses sent to models.  This is a region level setting and is not default
-* For CloudTrail, the eventSource = bedrock.amazonaws.com
+* For CloudTrail, the eventSource = bedrock.amazonaws.com, or bedrock-mantle.amazonaws.com for Bedrock Mantle
 * The ***InvokeModel*** API is a **read-only** event
 
 ### Event Names


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The bearer-token EventBridge rule only matched `additionalEventData.callWithBearerToken`, so it catches standard Bedrock (`bedrock.amazonaws.com`) but misses Bedrock Mantle (`bedrock-mantle.amazonaws.com`). Mantle accepts the same Bedrock API keys but records the flag in `requestParameters.callWithBearerToken`.

This matches both paths via `$or`, and documents Mantle's eventSource and field path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
